### PR TITLE
Fix bit extraction in parser

### DIFF
--- a/cosa/utils/formula_mngm.py
+++ b/cosa/utils/formula_mngm.py
@@ -75,7 +75,7 @@ def quote_names(strformula, prefix=None, replace_ops=True):
         lst_names.append(prefix)
     strformula = strformula.replace("\\","")
 
-    lits = [(len(x), x) for x in list(re.findall("([a-zA-Z][a-zA-Z_$\.0-9\[\]]*)+", strformula)) if x not in KEYWORDS]
+    lits = [(len(x), x) for x in list(re.findall("([a-zA-Z][a-zA-Z_$\.0-9]*)+", strformula)) if x not in KEYWORDS]
     lits.sort()
     lits.reverse()
     lits = [x[1] for x in lits]


### PR DESCRIPTION
Use pysmt semantics for square bracket bit-extract/array access

Note: This will no longer add quotes around symbol names with square
brackets, because these could be an extract op. In general, I feel
that square brackets in a name should be a syntax error, especially if
Verilog is one of the main input formats