### PR TITLE
Fix array printing for VCDs (print everything when asked for full-trace)

### DIFF
--- a/cosa/analyzers/dispatcher.py
+++ b/cosa/analyzers/dispatcher.py
@@ -110,6 +110,7 @@ class ProblemSolver(object):
         vcd_trace = None
         if problem.vcd:
             vcd_printer = VCDTracePrinter()
+            vcd_printer.all_vars = all_vars
             vcd_trace = vcd_printer.print_trace(hts=hts, \
                                                 model=trace.model, \
                                                 length=trace.length, \


### PR DESCRIPTION
This fixes array printing for VCD traces. Not all array values at a given time step were included in the trace (even if they'd been written to). This relates to the array_assigned_values_map dictionary implementation. Now, if the index has been written to, it will always print.

Furthermore, if the user asks for --full-trace then every index will print at every timestep (this also shows default initial array values).