### PR TITLE
Update to latest pycoreir which uses hwtypes instead of bit_vector

### DIFF
--- a/cosa/encoders/coreir.py
+++ b/cosa/encoders/coreir.py
@@ -366,15 +366,9 @@ class CoreIRParser(ModelParser):
                 else:
                     if type(xval) != int:
                         try:
-                            if xval.is_x():
-                                xval = None
-                            else:
-                                xval = xval.as_uint()
+                            xval = xval.as_uint()
                         except:
-                            try:
-                                xval = xval.val
-                            except:
-                                xval = xval.unsigned_value
+                            xval = None
                 return xval
 
             if inst_mod.generated:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='CoSA',
       license='BSD',
       packages = find_packages(),
       include_package_data = True,
-      install_requires=["six","pyparsing","pysmt","coreir","pyverilog"],
+      install_requires=["six","pyparsing","pysmt","coreir","pyverilog","hwtypes"],
       entry_points={
           'console_scripts': [
               'CoSA = cosa.shell:main'


### PR DESCRIPTION
Changes to coreir/pycoreir involve changing from the bit_vector package to hwtypes which has a BitVector implementation using SMT-LIB2 semantics. This updates our coreir encoder to use the correct functions and adds hwtypes as a dependency.