### PR TITLE
Convert booleans to bv and add missing op

### DIFF
--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -10,7 +10,7 @@
 
 import os
 
-from pysmt.shortcuts import Not, TRUE, And, BVNot, BVAnd, BVOr, BVAdd, Or, Symbol, BV, EqualsOrIff, \
+from pysmt.shortcuts import Not, TRUE, And, BVNot, BVNeg, BVAnd, BVOr, BVAdd, Or, Symbol, BV, EqualsOrIff, \
     Implies, BVMul, BVExtract, BVUGT, BVUGE, BVULT, BVULE, BVSGT, BVSGE, BVSLT, BVSLE, \
     Ite, BVZExt, BVSExt, BVXor, BVConcat, get_type, BVSub, Xor, Select, Store, BVComp, simplify, \
     BVLShl, BVAShr, BVLShr
@@ -63,6 +63,7 @@ IMPLIES="implies"
 OR="or"
 ITE="ite"
 NOT="not"
+NEG="neg"
 REDOR="redor"
 REDAND="redand"
 UEXT="uext"
@@ -254,6 +255,9 @@ class BTOR2Parser(ModelParser):
 
             if ntype == NOT:
                 nodemap[nid] = unary_op(BVNot, Not, getnode(nids[1]))
+
+            if ntype == NEG:
+                nodemap[nid] = unary_op(BVNeg, Not, getnode(nids[1]))
 
             if ntype == UEXT:
                 nodemap[nid] = BVZExt(B2BV(getnode(nids[1])), int(nids[2]))

--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -317,7 +317,7 @@ class BTOR2Parser(ModelParser):
 
             if ntype == ITE:
                 if (get_type(getnode(nids[2])) == BOOL) or (get_type(getnode(nids[3])) == BOOL):
-                    nodemap[nid] = Ite(BV2B(getnode(nids[1])), BV2B(getnode(nids[2])), BV2B(getnode(nids[3])))
+                    nodemap[nid] = Ite(BV2B(getnode(nids[1])), B2BV(getnode(nids[2])), B2BV(getnode(nids[3])))
                 else:
                     nodemap[nid] = Ite(BV2B(getnode(nids[1])), getnode(nids[2]), getnode(nids[3]))
 


### PR DESCRIPTION
In the btor encoder, every node should be a bit-vector unless it's a constraint. The ITE case had a conditional that would turn bit-vectors to booleans when it should have been booleans to bit-vectors.

We were also missing the bit-vector negation op ('neg') which this pull request adds.