### PR TITLE
Add hwtypes dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ addons:
      - python3-nose
      - iverilog
      - libreadline-dev
+     - libmpfr-dev
+     - libmpc-dev
 
 install:
   - pip install -e .


### PR DESCRIPTION
The `hwtypes` module is adding floating point support and thus there are two new dependencies: https://github.com/leonardt/hwtypes/pull/34.

They seem willing to factor out the FP support into its own package so that we don't have these extra dependencies, filed an issue here https://github.com/leonardt/hwtypes/issues/37.


