### PR TITLE
Use a trailing state variable for the coreir explicit clock

### DIFF
--- a/cosa/encoders/coreir.py
+++ b/cosa/encoders/coreir.py
@@ -26,6 +26,7 @@ from cosa.utils.generic import is_number, status_bar
 from cosa.utils.logger import Logger
 from cosa.encoders.template import ModelParser, ModelFlags, ModelInformation
 from cosa.encoders.modules import Modules, ModuleSymbols, SEP, CSEP
+from cosa.printers.template import HIDDEN_VAR
 from cosa.utils.generic import bin_to_dec, suppress_output, restore_output
 
 CR = "_const_replacement"
@@ -495,7 +496,9 @@ class CoreIRParser(ModelParser):
                     #   be violated trivially
                     # e.g. on a neg-edge clock, this new state element will have changed
 
-                    trailing_clock_var = self.BVVar(varname + "-prev", var[1].size)
+                    # make it hidden (won't be printed)
+                    # HIDDEN_VAR is a prefix that printers check for
+                    trailing_clock_var = self.BVVar("{}{}__prev".format(HIDDEN_VAR, varname), var[1].size)
 
                     ts = TS()
                     ts.add_state_var(trailing_clock_var)


### PR DESCRIPTION
This pull request adds a new state variable that is updated with the current clock value. This is an alternative fix for the issue addressed here: https://github.com/cristian-mattarei/CoSA/pull/64#issue-274457838, actual commit hash: 4272108d3ddc5237efa9a4b3c8525cb1b161cb94. The change is a preemptive bug fix -- there hasn't been a case where this bug presents yet.

Here is a brief recap of the original problem, but please see the previous pull request linked above for more information. It is required for model checking soundness that there be some representation of the clock in either the state or output variables.

This is because if we're performing k-induction, there is a "loop-free" constraint which is one of the ways a proof can converge. Loop-free means that the same state does not occur twice in the trace. If we have an explicit clock encoding, then state variables are only updated at the positive edge of the clock. Thus, at the negative edge of the clock, we are trivially loop-free. Unless, we incorporate the clock into this loop-free check somehow.

The previous fix just added the clock itself to the state variables. However, there could be potential problems with this as well. For example, say that we use the `default_initial_value` command to set all uninitialized state variables to 1 in the initial state. If the clock is one of the state variables, it will be included. However, if we also use the clock generator, `DetClock(clk, 1)`, this toggles the clock and also *sets the initial state to 0*. This will immediately make all queries trivially `unsat`.

To combat this problem, we instead add a new state variable `H__clk__prev` that just trails the actual clock. The only constraint on this variable is: `next(H__clk__prev) = clk`. Now the scenario mentioned above is no longer problematic, `H__clk__prev` can have an initial state 1 while `clk` has initial state 0 without reaching absurdity.

Note: currently this trailing clock variable is unused. In the future, it might be nice to use this variable for the state update functions, as opposed to `!clk & next(clk)`. That requires much more work and is delegated to a future pull request.
