### PR TITLE
Set preferred variables if supported

### DIFF
--- a/cosa/analyzers/bmc_parametric.py
+++ b/cosa/analyzers/bmc_parametric.py
@@ -82,12 +82,10 @@ class BMCParametric(BMCSafety):
 
         monotonic = True
 
-        # FIXME : we should do this if the solver supports it
-        #         otherwise, we should prune the traces afterwards to show only minimal ones
-        #         and maybe print a performance warning
-        # if monotonic:
-        #     for p in parameters:
-        #         self.set_preferred((p, False))
+        # TODO: Verify that this works as expected
+        if monotonic:
+            for p in parameters:
+                self.set_preferred((p, False))
 
         self.region = FALSE()
 

--- a/cosa/analyzers/bmc_safety.py
+++ b/cosa/analyzers/bmc_safety.py
@@ -735,6 +735,14 @@ class BMCSafety(BMCSolver):
                 for j in range(t+1):
                     self._add_assertion(solver, self.at_ptime(constraints, j-1), "Addditional Constraints")
 
+            if self.preferred is not None:
+                try:
+                    for (var, val) in self.preferred:
+                        solver.solver.set_preferred_var(TS.get_timed(var, t), val)
+                except:
+                    Logger.warning("Current solver does not support preferred variables")
+                    self.preferred = None
+
             if (t >= k_min) and self._solve(solver):
                 Logger.log("Counterexample found with k=%s"%(t), 1)
                 model = self._get_model(solver)


### PR DESCRIPTION
For parametric model checking, you typically want the minimum fault configurations. This can be accomplished by enumerating all of them and checking for subsumption (expensive), or by setting the preferred value to False for fault variables as described in: https://link.springer.com/chapter/10.1007/978-3-319-21690-4_41.

This pull request simply sets preferred variables if the solver supports it (as far as I know, MathSAT - `msat` is the only solver that supports it). Note: `msat` is the default solver for CoSA.

@eshan-singh