### PR TITLE
Fix several issues with PosixPath

### DIFF
--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -10,6 +10,10 @@
 
 import os
 
+from pathlib import Path
+from typing import List, NamedTuple, Tuple
+
+from pysmt.fnode import FNode
 from pysmt.shortcuts import Not, TRUE, And, BVNot, BVNeg, BVAnd, BVOr, BVAdd, Or, Symbol, BV, EqualsOrIff, \
     Implies, BVMul, BVExtract, BVUGT, BVUGE, BVULT, BVULE, BVSGT, BVSGE, BVSLT, BVSLE, \
     Ite, BVZExt, BVSExt, BVXor, BVConcat, get_type, BVSub, Xor, Select, Store, BVComp, simplify, \
@@ -94,9 +98,12 @@ class BTOR2Parser(ModelParser):
     def get_model_info(self):
         return None
 
-    def parse_file(self, strfile, config, flags=None):
+    def parse_file(self,
+                   filepath:Path,
+                   config:NamedTuple,
+                   flags:str=None)->Tuple[HTS, List[FNode], List[FNode]]:
         self.symbolic_init = config.symbolic_init
-        with open(strfile, "r") as f:
+        with filepath.open("r") as f:
             return self.parse_string(f.read())
 
     def is_available(self):

--- a/cosa/encoders/explicit_transition_system.py
+++ b/cosa/encoders/explicit_transition_system.py
@@ -11,9 +11,10 @@
 import math
 from pathlib import Path
 import pyparsing
-from typing import NamedTuple
+from typing import List, NamedTuple, Tuple
 
 from pyparsing import Literal, Word, nums, alphas, OneOrMore, ZeroOrMore, restOfLine, LineEnd, Combine, White
+from pysmt.fnode import FNode
 from pysmt.shortcuts import TRUE, FALSE, And, Or, Symbol, BV, EqualsOrIff, Implies, BVULE
 from pysmt.typing import BOOL, BVType
 

--- a/cosa/encoders/symbolic_transition_system.py
+++ b/cosa/encoders/symbolic_transition_system.py
@@ -8,9 +8,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 import pyparsing
+from typing import List, NamedTuple, Tuple
 
 from pyparsing import Literal, Word, nums, alphas, OneOrMore, ZeroOrMore, Optional, restOfLine, LineEnd, Combine, White, Group, SkipTo, lineEnd
+from pysmt.fnode import FNode
 from pysmt.shortcuts import TRUE, And, Or, Symbol, BV, EqualsOrIff, Implies
 from pysmt.typing import BOOL, BVType
 
@@ -134,8 +137,11 @@ class SymbolicTSParser(ModelParser):
         self.parser.ignore(T_COM + SkipTo(lineEnd))
         self.pyparsing_version = pyparsing.__version__
 
-    def parse_file(self, strfile, config, flags=None):
-        with open(strfile, "r") as f:
+    def parse_file(self,
+                   filepath:Path,
+                   config:NamedTuple,
+                   flags:str=None)->Tuple[HTS, List[FNode], List[FNode]]:
+        with filepath.open("r") as f:
             return self.parse_string(f.read())
 
     def is_available(self):

--- a/cosa/encoders/symbolic_transition_system.py
+++ b/cosa/encoders/symbolic_transition_system.py
@@ -516,8 +516,11 @@ class SymbolicSimpleTSParser(ModelParser):
     def remap_or2an(self, name):
         return name
 
-    def parse_file(self, strfile, config, flags=None):
-        with open(strfile, "r") as f:
+    def parse_file(self,
+                   filepath:Path,
+                   config:NamedTuple,
+                   flags:str=None)->Tuple[HTS, List[FNode], List[FNode]]:
+        with filepath.open("r") as f:
             lines = (f.read().replace("\\\n","")).splitlines(True)
             return self.parse_string(lines)
 

--- a/cosa/encoders/template.py
+++ b/cosa/encoders/template.py
@@ -8,6 +8,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+from typing import List, NamedTuple, Tuple
+
+from pysmt.fnode import FNode
+
 from cosa.utils.logger import Logger
 
 class ModelFlags(object):
@@ -48,7 +53,10 @@ class ModelParser(object):
     def parse_string(self, string):
         Logger.error("Not implemented")
 
-    def parse_file(self, strfile, config, flags=None):
+    def parse_file(self,
+                   filepath:Path,
+                   config:NamedTuple,
+                   flags:str=None)->Tuple[HTS, List[FNode], List[FNode]]:
         Logger.error("Not implemented")
 
     def get_name(self):

--- a/cosa/encoders/template.py
+++ b/cosa/encoders/template.py
@@ -13,6 +13,7 @@ from typing import List, NamedTuple, Tuple
 
 from pysmt.fnode import FNode
 
+from cosa.representation import HTS
 from cosa.utils.logger import Logger
 
 class ModelFlags(object):

--- a/cosa/encoders/verilog_yosys.py
+++ b/cosa/encoders/verilog_yosys.py
@@ -79,7 +79,10 @@ class VerilogYosysBtorParser(ModelParser):
     def _get_extension(self, strfile):
         return strfile.split(".")[-1]
 
-    def parse_file(self, filepath, config, flags=None):
+    def parse_file(self,
+                   filepath:Path,
+                   config:NamedTuple,
+                   flags:str=None)->Tuple[HTS, List[FNode], List[FNode]]:
 
         # create copy of yosys commands (will be modified below)
         # Note: This class is only instantiated once per python environment

--- a/cosa/encoders/verilog_yosys.py
+++ b/cosa/encoders/verilog_yosys.py
@@ -9,16 +9,18 @@
 # limitations under the License.
 
 import os
-import shutil
+from pathlib import Path
 import re
+import shutil
+from typing import List, NamedTuple, Tuple
 
-from cosa.representation import HTS, TS
-from cosa.utils.logger import Logger
+from pysmt.fnode import FNode
 
 from cosa.encoders.template import ModelParser
 from cosa.encoders.btor2 import BTOR2Parser
-
+from cosa.representation import HTS, TS
 from cosa.utils.generic import suppress_output, restore_output, check_command
+from cosa.utils.logger import Logger
 
 PASSES = []
 PASSES.append("hierarchy -check")
@@ -162,7 +164,7 @@ class VerilogYosysBtorParser(ModelParser):
             Logger.error("Error in Verilog conversion.\nSee %s for more info."%YOSYSERRLOG)
 
         parser = BTOR2Parser()
-        ret = parser.parse_file(TMPFILE, config)
+        ret = parser.parse_file(Path(TMPFILE), config)
 
         if not Logger.level(1):
             os.remove(TMPFILE)


### PR DESCRIPTION
This affects versions of Python3 older than Python3.6. Passing a PosixPath object to `open` fails, so we need to be sure to use `path.open()` instead. These bugs did not present in Python3.6, which allows PosixPaths as an argument to `open`.