### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "3.6"
   - "3.5"
-  - "3.4"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ install:
   - chmod +x ./yosys
 
 env:
- - PATH="$PATH:." PYTHONPATH="${TRAVIS_BUILD_DIR}/pycoreir":"${TRAVIS_BUILD_DIR}/pysmt":"${TRAVIS_BUILD_DIR}/pysmt/bindings:${PYTHONPATH}" LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/coreir/lib":"${TRAVIS_BUILD_DIR}/pysmt/bindings:${LD_LIBRARY_PATH}" COREIRCONFIG=clang++ CC=clang CXX=clang++
+ - PATH="$PATH:." PYTHONPATH="${TRAVIS_BUILD_DIR}/pycoreir":"${TRAVIS_BUILD_DIR}/solvers/":"${TRAVIS_BUILD_DIR}/bindings:${PYTHONPATH}" LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/coreir/lib":"${TRAVIS_BUILD_DIR}/bindings:${TRAVIS_BUILD_DIR}/solvers:${LD_LIBRARY_PATH}" COREIRCONFIG=clang++ CC=clang CXX=clang++
 
-script: nosetests tests -vv
+# script: nosetests tests -vv
+script: python -c "import mathsat"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,4 @@ install:
 env:
  - PATH="$PATH:." PYTHONPATH="${TRAVIS_BUILD_DIR}/pycoreir":"${TRAVIS_BUILD_DIR}/solvers/":"${TRAVIS_BUILD_DIR}/bindings:${PYTHONPATH}" LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/coreir/lib":"${TRAVIS_BUILD_DIR}/bindings:${TRAVIS_BUILD_DIR}/solvers:${LD_LIBRARY_PATH}" COREIRCONFIG=clang++ CC=clang CXX=clang++
 
-# script: nosetests tests -vv
-script: python -c "import mathsat"
+script: nosetests tests -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
   - "3.6"
-  - "3.5"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ addons:
 
 install:
   - pip install -e .
+  - pysmt-install --msat --confirm-agreement --install-path solvers --bindings-path bindings
   - bash ./scripts/travis_install.sh
   - chmod +x ./yosys
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: xenial
 language: python
 python:
   - "3.6"
+  - "3.5"
+  - "3.4"
 
 sudo: required
 

--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,7 @@ Installation
 
 Software requirements:
 
-- `Python3`_
-  - Full support requires Python3.6 or higher, however running without the `CoreIR`_ inputs should work on older Python 3 versions
+- `Python3`_ -- Full support requires Python3.6 or higher, however running without the `CoreIR`_ inputs should work on older Python 3 versions
 - `Pip3`_: package manager -- easiest way to install CoSA. On Debian: `apt-get update; apt-get install python3-pip`.
 - `Cmake`_ and a standard C++ compiler for `CoreIR`_ / `PyCoreIR`_
 - `Yosys`_ needs to be installed in order to support Verilog as an input format

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Installation
 Software requirements:
 
 - `Python3`_
+  - Full support requires Python3.6 or higher, however running without the `CoreIR`_ inputs should work on older Python 3 versions
 - `Pip3`_: package manager -- easiest way to install CoSA. On Debian: `apt-get update; apt-get install python3-pip`.
 - `Cmake`_ and a standard C++ compiler for `CoreIR`_ / `PyCoreIR`_
 - `Yosys`_ needs to be installed in order to support Verilog as an input format

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+PYCOREIR="`pwd`/pycoreir/setup.py"
+COREIR="`pwd`/coreir/build"
+
+if [ ! -f "$COREIR" ]; then
+    rm -fr coreir*
+    wget https://github.com/rdaly525/coreir/archive/master.zip
+    unzip master.zip
+    rm master.zip
+    mv coreir-master coreir
+    cd coreir
+    mkdir build
+    cd build
+    cmake ..
+    make -j4 && sudo make install
+    cd ../../
+else
+    echo "Skipping COREIR installation"
+    cd coreir/build
+    make -j4 && sudo make install
+    cd ../../
+fi
+
 # Get yosys -- using for verilog frontend
 wget http://web.stanford.edu/~makaim/files/yosys.tar.xz
 tar -xf yosys.tar.xz

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -2,25 +2,6 @@
 
 PYCOREIR="`pwd`/pycoreir/setup.py"
 COREIR="`pwd`/coreir/build"
-PYSMT="`pwd`/pysmt/setup.py"
-BITVECTOR="`pwd`/bit_vector/setup.py"
-
-if [ ! -f "$PYSMT" ]; then
-    rm -fr pysmt*
-    # TEMP PySMT currently errors out upstream
-    git clone -b cosa https://github.com/makaimann/pysmt.git
-    # wget https://github.com/pysmt/pysmt/archive/master.zip
-    # unzip master.zip
-    # rm master.zip
-    # mv pysmt-master pysmt
-    cd pysmt
-    pip3 install -e .
-    pysmt-install --msat --confirm-agreement --install-path solvers --bindings-path bindings
-    cd ..
-else
-    echo "Skipping PYSMT installation"
-    cd pysmt && pip3 install -e . && cd ..
-fi
 
 if [ ! -f "$COREIR" ]; then
     rm -fr coreir*

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -42,4 +42,5 @@ else
 fi
 
 # Get yosys -- using for verilog frontend
-wget http://web.stanford.edu/~makaim/files/yosys
+wget http://web.stanford.edu/~makaim/files/yosys.tar.xz
+tar -xf yosys.tar.xz

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -1,27 +1,5 @@
 #!/bin/bash
 
-PYCOREIR="`pwd`/pycoreir/setup.py"
-COREIR="`pwd`/coreir/build"
-
-if [ ! -f "$COREIR" ]; then
-    rm -fr coreir*
-    wget https://github.com/rdaly525/coreir/archive/master.zip
-    unzip master.zip
-    rm master.zip
-    mv coreir-master coreir
-    cd coreir
-    mkdir build
-    cd build
-    cmake ..
-    make -j4 && sudo make install
-    cd ../../
-else
-    echo "Skipping COREIR installation"
-    cd coreir/build
-    make -j4 && sudo make install
-    cd ../../
-fi
-
 # Get yosys -- using for verilog frontend
 wget http://web.stanford.edu/~makaim/files/yosys.tar.xz
 tar -xf yosys.tar.xz


### PR DESCRIPTION
This pull request just makes a couple small improvements for the CoSA travis build:

* it downloads a statically compiled version of Yosys instead of building it on the VM
* it relies on the pip installation of pysmt instead of rebuilding a fork of it

There were several things I wanted to do that didn't end up working out:

* rely on pip installation of `pycoreir` to build `coreir` -- for some reason this doesn't seem to install properly
* test multiple python versions -- `pycoreir` requires 3.6 or later, so I think we're stuck with that. 
  * I added a note in the README to say that we require 3.6 but that it's possible to use other features of CoSA with older python3 versions

Note: there are lots of debug commits in this pull request, so I'd especially like this one to be a squash merge.