### PR TITLE
Add a top-level scope and remove the extra  in vcd printer

### DIFF
--- a/cosa/printers/trace.py
+++ b/cosa/printers/trace.py
@@ -254,6 +254,7 @@ class VCDTracePrinter(TracePrinter):
             else:
                 Logger.error("Unhandled type in VCD printer")
 
+        ret.append("$scope module top $end")
         for el in varlist + arr_varlist:
             (varname, width) = el
             idvar = var2id[varname]
@@ -272,7 +273,6 @@ class VCDTracePrinter(TracePrinter):
                 ret.append("$var reg %d v%s %s[%d:0] $end"%(width, idvar, varname, width-1))
 
 
-        ret.append("$upscope $end")
         ret.append("$upscope $end")
         ret.append("$enddefinitions $end")
 


### PR DESCRIPTION
Very minor fixes to vcd printer. In the future, we could use the actual top-level module name, but that information is not currently carried through. For now, `top` works.