### PR TITLE
Add support for arrays to translation backend and STS/SSTS frontend

### DIFF
--- a/cosa/analyzers/dispatcher.py
+++ b/cosa/analyzers/dispatcher.py
@@ -151,6 +151,10 @@ class ProblemSolver(object):
         bmc_length = problem.bmc_length
         bmc_length_min = problem.bmc_length_min
 
+        if problem.verification is None:
+            Logger.log("Skipping problem because no verification is selected.", 0)
+            return None, None, None, None
+
         if problem.verification == VerificationType.SAFETY:
             accepted_ver = True
             Logger.log("Property: %s"%(prop.serialize(threshold=100)), 2)
@@ -573,7 +577,8 @@ class ProblemSolver(object):
                     assert region is not None
                     problems_config.set_problem_region(problem, region)
 
-                Logger.msg(" %s\n"%status, 0, not(Logger.level(1)))
+                if status is not None:
+                    Logger.msg(" %s\n"%status, 0, not(Logger.level(1)))
 
                 if (assume_if_true) and \
                    (status == VerificationStatus.TRUE) and \

--- a/cosa/analyzers/dispatcher.py
+++ b/cosa/analyzers/dispatcher.py
@@ -61,6 +61,7 @@ class ProblemSolver(object):
         self.lparser = None
         self.coi = None
         self.model_info = ModelInformation()
+        self.properties = [] # contains the parsed properties -- PySMT objects
 
         GeneratorsFactory.init_generators()
         ClockBehaviorsFactory.init_clockbehaviors()
@@ -449,11 +450,13 @@ class ProblemSolver(object):
                                         name=invar_prop[0],
                                         description=invar_prop[1],
                                         properties=invar_prop[2])
+            self.properties.append(invar_prop[2])
         for ltl_prop in ltl_props:
             problems_config.add_problem(verification=VerificationType.LTL,
                                         name=invar_prop[0],
                                         description=invar_prop[1],
                                         properties=invar_prop[2])
+            self.properties.append(ltl_prop[2])
 
         Logger.log("Solving with abstract_clock=%s, add_clock=%s"%(general_config.abstract_clock,
                                                                    general_config.add_clock), 2)
@@ -502,6 +505,7 @@ class ProblemSolver(object):
                     assert len(prop) == 1, "Properties should already have been split into " \
                         "multiple problems but found {} properties here".format(len(prop))
                     prop = prop[0]
+                    self.properties.append(prop)
                 else:
                     if problem.verification == VerificationType.SIMULATION:
                         prop = TRUE()

--- a/cosa/encoders/symbolic_transition_system.py
+++ b/cosa/encoders/symbolic_transition_system.py
@@ -10,16 +10,17 @@
 
 from pathlib import Path
 import pyparsing
+from pyparsing import Literal, Word, nums, alphas, OneOrMore, ZeroOrMore, Optional, Forward, restOfLine, LineEnd, Combine, White, Group, SkipTo, lineEnd
 from typing import List, NamedTuple, Tuple
 
-from pyparsing import Literal, Word, nums, alphas, OneOrMore, ZeroOrMore, Optional, restOfLine, LineEnd, Combine, White, Group, SkipTo, lineEnd
+from pysmt.exceptions import UndefinedSymbolError
 from pysmt.fnode import FNode
 from pysmt.shortcuts import TRUE, And, Or, Symbol, BV, EqualsOrIff, Implies
 from pysmt.typing import BOOL, BVType
 
 from cosa.representation import HTS, TS
 from cosa.utils.logger import Logger
-from cosa.utils.formula_mngm import quote_names
+from cosa.utils.formula_mngm import parse_typestr, to_typestr, quote_names
 from cosa.encoders.template import ModelParser
 from cosa.encoders.formulae import StringParser
 
@@ -62,6 +63,7 @@ T_FTRANS = "FUNC"
 T_INVAR = "INVAR"
 T_DEF = "DEF"
 
+T_ARRAY = "Array"
 T_BV = "BV"
 T_BOOL = "Bool"
 
@@ -200,9 +202,13 @@ class SymbolicTSParser(ModelParser):
                 for vardef in self._split_list(vardefs, T_CM):
                     varname = vardef[0]
                     vartype = vardef[2]
-                    varpar = vardef[4:-1] if vartype != T_BOOL else None
 
-                    par_str.append((varname, vartype, varpar))
+                    try:
+                        vartype = parse_typestr(vartype)
+                        par_str.append((varname, vartype))
+                    except UndefinedSymbolError:
+                        varpar = vardef[4:-1]
+                        par_str.append((varname, vartype, varpar))
 
             dpsts = dict(psts)
 
@@ -218,11 +224,11 @@ class SymbolicTSParser(ModelParser):
                          varname = varname[1:-1]
 
                     vartype = vardef[2]
-                    varpar = vardef[4:-1] if vartype != T_BOOL else None
-
-                    if vartype in (T_BV, T_BOOL):
-                        var_str.append((varname, vartype, varpar))
-                    else:
+                    try:
+                        vartype = parse_typestr(vartype)
+                        var_str.append((varname, vartype))
+                    except UndefinedSymbolError:
+                        varpar = vardef[4:-1]
                         sub_str.append((varname, vartype, self._split_list(varpar, T_CM)))
 
             if P_STATEDEFS in dpsts:
@@ -236,10 +242,8 @@ class SymbolicTSParser(ModelParser):
                     if statename[0] == "'":
                          statename = statename[1:-1]
 
-                    statetype = statedef[2]
-                    statepar = statedef[4:-1] if statetype != T_BOOL else None
-
-                    state_str.append((statename, statetype, statepar))
+                    statetype = parse_typestr(statedef[2])
+                    state_str.append((statename, statetype))
 
             if P_INPUTDEFS in dpsts:
                 if self.pyparsing_version == PYPARSING_220:
@@ -252,10 +256,8 @@ class SymbolicTSParser(ModelParser):
                     if inputname[0] == "'":
                          inputname = inputname[1:-1]
 
-                    inputtype = inputdef[2]
-                    inputpar = inputdef[4:-1] if inputtype != T_BOOL else None
-
-                    input_str.append((inputname, inputtype, inputpar))
+                    inputtype = parse_typestr(inputdef[2])
+                    input_str.append((inputname, inputtype))
 
             if P_OUTPUTDEFS in dpsts:
                 if self.pyparsing_version == PYPARSING_220:
@@ -268,10 +270,8 @@ class SymbolicTSParser(ModelParser):
                     if outputname[0] == "'":
                          outputname = outputname[1:-1]
 
-                    outputtype = outputdef[2]
-                    outputpar = outputdef[4:-1] if outputtype != T_BOOL else None
-
-                    output_str.append((outputname, outputtype, outputpar))
+                    outputtype = parse_typestr(outputdef[2])
+                    output_str.append((outputname, outputtype))
 
             if P_INIT in dpsts:
                 if self.pyparsing_version == PYPARSING_220:
@@ -320,7 +320,11 @@ class SymbolicTSParser(ModelParser):
         varsize = (Word(nums))(P_VARSIZE)
         parlist = (ZeroOrMore(varname)+ZeroOrMore((Literal(T_CM) + varname)))
         modtype = (Word(alphas+T_US+nums) + Literal(T_OP) + parlist + Literal(T_CP))(P_MODTYPE)
-        basictype = (Literal(T_BV) + Literal(T_OP) + varsize + Literal(T_CP)) | Literal(T_BOOL)
+
+        basictype = Forward()
+        basictype << (Combine(Literal(T_BV) + Literal(T_OP) + varsize + Literal(T_CP)) | Combine(Literal(T_BOOL)) |
+                      Combine(Literal(T_ARRAY) + Literal(T_OP) + basictype + Literal(T_CM) + basictype + Literal(T_CP)))
+
         vartype = (basictype | modtype)(P_VARTYPE)
         vartypedef = (vartype)(P_VARTYPEDEF)
         vardef = varname + Literal(T_CL) + vartypedef + Literal(T_SC)
@@ -345,27 +349,9 @@ class SymbolicTSParser(ModelParser):
         return (OneOrMore(sts))(P_STSS)
 
     def _define_var(self, var, prefix=""):
-        varname, (vartype, size) = var
+        varname, vartype = var
         fullname = self._concat_names(prefix, varname)
-
-        if vartype == T_BV:
-            return Symbol(fullname, BVType(int(size[0])))
-
-        if vartype == T_BOOL:
-            return Symbol(fullname, BOOL)
-
-        Logger.error("Unsupported type: %s"%vartype)
-
-    def _get_type(self, strtype):
-        (vartype, size) = strtype
-
-        if vartype == T_BV:
-            return BVType(int(size[0]))
-
-        if vartype == T_BOOL:
-            return BOOL
-
-        Logger.error("Unsupported type: %s"%vartype)
+        return Symbol(fullname, vartype)
 
     def _concat_names(self, prefix, name):
         return ".".join([x for x in [prefix,name] if x != ""])
@@ -373,16 +359,16 @@ class SymbolicTSParser(ModelParser):
     def _collect_sub_variables(self, module, modulesdic, path, varlist, statelist, inputlist, outputlist):
 
         for var in module.vars+module.pars:
-            varlist.append((".".join(path+[str(var[0])]), var[1:]))
+            varlist.append((".".join(path+[str(var[0])]), var[1]))
 
         for var in module.states:
-            statelist.append((".".join(path+[str(var[0])]), var[1:]))
+            statelist.append((".".join(path+[str(var[0])]), var[1]))
 
         for var in module.inputs:
-            inputlist.append((".".join(path+[str(var[0])]), var[1:]))
+            inputlist.append((".".join(path+[str(var[0])]), var[1]))
 
         for var in module.outputs:
-            outputlist.append((".".join(path+[str(var[0])]), var[1:]))
+            outputlist.append((".".join(path+[str(var[0])]), var[1]))
 
         for sub in module.subs:
             (varlist, statelist, inputlist, outputlist) = self._collect_sub_variables(modulesdic[sub[1]], modulesdic, path + [sub[0]], varlist, statelist, inputlist, outputlist)
@@ -394,7 +380,7 @@ class SymbolicTSParser(ModelParser):
         vartypes = dict([(v.symbol_name(), v.symbol_type()) for v in vars_])
 
         for sub in module.subs:
-            formal_pars = [self._get_type(t[1:]) for t in modulesdic[sub[1]].pars]
+            formal_pars = [t[1] for t in modulesdic[sub[1]].pars]
             actual_pars = [vartypes[self._concat_names(module.name, v[0])] for v in sub[2]]
 
             if formal_pars != actual_pars:
@@ -428,7 +414,8 @@ class SymbolicTSParser(ModelParser):
         self._check_parameters(module, modulesdic, ts.vars)
 
         for par in module.pars:
-            hts.add_param(self._define_var((par[0], tuple(par[1:])), module.name))
+            assert len(par) == 2, "Expecting a variable"
+            hts.add_param(self._define_var((par[0], par[1]), module.name))
 
         for init_s in module.init:
             formula = sparser.parse_formula(quote_names(init_s, module.name), False)
@@ -525,14 +512,7 @@ class SymbolicSimpleTSParser(ModelParser):
             return self.parse_string(lines)
 
     def _define_var(self, varname, vartype):
-        if vartype == T_BOOL:
-            return Symbol(varname, BOOL)
-
-        if vartype[0] == T_BV:
-            vartype, size = vartype[0], vartype[1]
-            return Symbol(varname, BVType(int(size)))
-
-        Logger.error("Unsupported type: %s"%vartype)
+        return Symbol(varname, vartype)
 
     def parse_string(self, lines):
 
@@ -593,10 +573,10 @@ class SymbolicSimpleTSParser(ModelParser):
                 continue
 
             if section in [var, state, input, output]:
-                line = line[:-2].replace(" ","").split(":")
-                varname, vartype = line[0], (line[1][:-1].split("(")) if "(" in line[1] else line[1]
+                varname, vartype = line[:-2].replace(" ","").split(":")
                 if varname[0] == "'":
                     varname = varname[1:-1]
+                vartype = parse_typestr(vartype)
                 vardef = self._define_var(varname, vartype)
 
                 vars.add(vardef)

--- a/cosa/options.py
+++ b/cosa/options.py
@@ -317,7 +317,7 @@ verification_choices = [
 ver_options.set_defaults(verification=None)
 ver_options.add_argument('--verification', type=str,
                          choices=verification_choices,
-                         help="Choose the verification type from: {}"
+                         help="Choose the verification type from: \n{}"
                          "".format("\n".join("\t%s"%v for v in verification_choices)))
 
 # Verification parameters

--- a/cosa/printers/hts.py
+++ b/cosa/printers/hts.py
@@ -64,19 +64,10 @@ class SMVHTSPrinter(HTSPrinter):
     def print_hts(self, hts, properties=None):
         self.write("MODULE main\n")
 
-        if properties is not None:
-            for prop in properties:
-                self.write('\nPROPERTY')
-                self.write(prop)
-                self.write(';\n')
-            # TODO: decide if it's important to identify the property type
-            # for strprop, prop, _ in properties:
-            #     if has_ltl_operators(prop):
-            #         self.write("\nLTLSPEC ")
-            #     else:
-            #         self.write("\nINVARSPEC ")
-            #     self.printer(prop)
-            #     self.write(";\n")
+        printed_vars = set([])
+        self.__print_single_ts(hts.get_TS(), printed_vars)
+        # for ts in hts.tss:
+        #     printed_vars = self.__print_single_ts(ts, printed_vars)
 
         if hts.assumptions is not None:
             self.write("\n-- ASSUMPTIONS\n")
@@ -85,14 +76,19 @@ class SMVHTSPrinter(HTSPrinter):
                 self.printer(assmp)
                 self.write(";\n")
 
-        printed_vars = set([])
-        self.__print_single_ts(hts.get_TS(), printed_vars)
-        # for ts in hts.tss:
-        #     printed_vars = self.__print_single_ts(ts, printed_vars)
+        if properties is not None:
+            for prop in properties:
+                if has_ltl_operators(prop):
+                    self.write('\nLTLSPEC ')
+                else:
+                    self.write('\nINVARSPEC ')
+                self.printer(prop)
+                self.write('\n')
 
         ret = self.stream.getvalue()
         self.stream.truncate(0)
         self.stream.seek(0)
+
         return ret
 
     def __print_single_ts(self, ts, printed_vars):

--- a/cosa/printers/hts.py
+++ b/cosa/printers/hts.py
@@ -24,7 +24,7 @@ from cosa.encoders.coreir import SEP
 from cosa.utils.generic import dec_to_bin, dec_to_hex
 from cosa.encoders.ltl import has_ltl_operators
 from cosa.environment import ExtHRPrinter
-from cosa.utils.formula_mngm import get_free_variables
+from cosa.utils.formula_mngm import get_free_variables, to_typestr
 from cosa.utils.generic import sort_system_variables
 
 from cosa.printers.template import HTSPrinter, HTSPrinterType
@@ -201,10 +201,8 @@ class STSHTSPrinter(HTSPrinter):
             varsort = sort_system_variables(vars)
             for var in varsort:
                 sname = self.names(var.symbol_name())
-                if var.symbol_type() == BOOL:
-                    self.write("%s : Bool;\n"%(sname))
-                else:
-                    self.write("%s : BV(%s);\n"%(sname, var.symbol_type().width))
+                typestr = to_typestr(var.symbol_type())
+                self.write("{} : {};\n".format(sname, typestr))
             self.write("\n")
 
         sections = [((ts.init),"INIT"), ((ts.invar),"INVAR"), ((ts.trans),"TRANS")]

--- a/cosa/printers/hts.py
+++ b/cosa/printers/hts.py
@@ -66,8 +66,6 @@ class SMVHTSPrinter(HTSPrinter):
 
         printed_vars = set([])
         self.__print_single_ts(hts.get_TS(), printed_vars)
-        # for ts in hts.tss:
-        #     printed_vars = self.__print_single_ts(ts, printed_vars)
 
         if hts.assumptions is not None:
             self.write("\n-- ASSUMPTIONS\n")

--- a/cosa/shell.py
+++ b/cosa/shell.py
@@ -14,6 +14,7 @@ import sys
 from typing import List, NamedTuple, Union
 
 from pysmt.shortcuts import TRUE, FALSE
+from pysmt.fnode import FNode
 
 from cosa.analyzers.dispatcher import ProblemSolver, FILE_SP, MODEL_SP
 from cosa.environment import reset_env
@@ -83,7 +84,7 @@ def translate(hts, config, formulae=None):
         for f in formulae:
             if f is None:
                 continue
-            assert isinstance(f, str), "Expecting strings from problem configuration"
+            assert isinstance(f, FNode), "Expecting parsed properties"
             props.append(f)
 
     with open(config.translate, "w") as f:
@@ -174,7 +175,6 @@ def run_problems(problems_config:ProblemsManager):
             Logger.log("No problems to solve", 0)
             return 0
 
-    formulae = []
     for pbm in problems_config.problems:
         (status, trace) = print_problem_result(pbm,
                                                problems_config)
@@ -182,7 +182,6 @@ def run_problems(problems_config:ProblemsManager):
         if status != 0:
             global_status = status
         traces += trace
-        formulae.append(pbm.properties)
 
     if len(traces) > 0:
         Logger.log("\n*** TRACES ***\n", 0)
@@ -190,7 +189,8 @@ def run_problems(problems_config:ProblemsManager):
             Logger.log("[%d]:\t%s"%(traces.index(trace)+1, trace), 0)
 
     if general_config.translate:
-        translate(problems_config.hts, general_config, formulae)
+        # using parsed properties from ProblemSolver
+        translate(problems_config.hts, general_config, psol.properties)
 
     if global_status != 0:
         Logger.log("", 0)

--- a/cosa/shell.py
+++ b/cosa/shell.py
@@ -176,12 +176,13 @@ def run_problems(problems_config:ProblemsManager):
             return 0
 
     for pbm in problems_config.problems:
-        (status, trace) = print_problem_result(pbm,
-                                               problems_config)
+        if pbm.verification is not None:
+            (status, trace) = print_problem_result(pbm,
+                                                   problems_config)
 
-        if status != 0:
-            global_status = status
-        traces += trace
+            if status != 0:
+                global_status = status
+            traces += trace
 
     if len(traces) > 0:
         Logger.log("\n*** TRACES ***\n", 0)

--- a/cosa/utils/formula_mngm.py
+++ b/cosa/utils/formula_mngm.py
@@ -37,6 +37,10 @@ def parse_typestr(string:str)->PySMTType:
     return parse(string.replace("(", "{").replace(")", "}"))
 
 def to_typestr(_type:PySMTType)->str:
+    '''
+    Converts a PySMTType to the CoSA string representation, i.e.
+    using parentheses instead of curly brackets
+    '''
     return str(_type).replace("{", "(").replace("}", ")")
 
 class SubstituteWalker(IdentityDagWalker):

--- a/cosa/utils/formula_mngm.py
+++ b/cosa/utils/formula_mngm.py
@@ -12,8 +12,9 @@ import itertools
 import re
 
 from pysmt.walkers.identitydag import IdentityDagWalker
+from pysmt.parsing import parse
 from pysmt.shortcuts import Ite, EqualsOrIff, BV, get_type, simplify, And, Or
-from pysmt.typing import BOOL, BVType, ArrayType
+from pysmt.typing import BOOL, BVType, ArrayType, PySMTType
 
 from cosa.utils.generic import new_string
 
@@ -26,6 +27,17 @@ def BV2B(f):
     if get_type(f).is_bool_type():
         return f
     return EqualsOrIff(f, BV(1,1))
+
+def parse_typestr(string:str)->PySMTType:
+    '''
+    Takes a string and returns the PySMTType.
+    We use parentheses instead of curly-brackets in CoSA, e.g.
+    Array(BV(3), BV(8)) instead of Array{BV{3}, BV{8}}
+    '''
+    return parse(string.replace("(", "{").replace(")", "}"))
+
+def to_typestr(_type:PySMTType)->str:
+    return str(_type).replace("{", "(").replace("}", ")")
 
 class SubstituteWalker(IdentityDagWalker):
 


### PR DESCRIPTION
Adds support for dumping SMV or SSTS files with arrays in them. It also fixes the property outputs for SMV so we can now run nuXmv directly on the output.

Furthermore, this adds support for reading in STS/SSTS files that include arrays.