### PR TITLE
Add option to skip embedded assertions

### DIFF
--- a/cosa/analyzers/dispatcher.py
+++ b/cosa/analyzers/dispatcher.py
@@ -458,18 +458,19 @@ class ProblemSolver(object):
         problems_config.hts = hts
 
         # TODO: Update this so that we can control whether embedded assertions are solved automatically
-        for invar_prop in invar_props:
-            problems_config.add_problem(verification=VerificationType.SAFETY,
-                                        name=invar_prop[0],
-                                        description=invar_prop[1],
-                                        properties=invar_prop[2])
-            self.properties.append(invar_prop[2])
-        for ltl_prop in ltl_props:
-            problems_config.add_problem(verification=VerificationType.LTL,
-                                        name=invar_prop[0],
-                                        description=invar_prop[1],
-                                        properties=invar_prop[2])
-            self.properties.append(ltl_prop[2])
+        if not general_config.skip_embedded:
+            for invar_prop in invar_props:
+                problems_config.add_problem(verification=VerificationType.SAFETY,
+                                            name=invar_prop[0],
+                                            description=invar_prop[1],
+                                            properties=invar_prop[2])
+                self.properties.append(invar_prop[2])
+            for ltl_prop in ltl_props:
+                problems_config.add_problem(verification=VerificationType.LTL,
+                                            name=invar_prop[0],
+                                            description=invar_prop[1],
+                                            properties=invar_prop[2])
+                self.properties.append(ltl_prop[2])
 
         Logger.log("Solving with abstract_clock=%s, add_clock=%s"%(general_config.abstract_clock,
                                                                    general_config.add_clock), 2)

--- a/cosa/options.py
+++ b/cosa/options.py
@@ -220,6 +220,10 @@ general_solving_options.set_defaults(assume_if_true=False)
 general_solving_options.add_argument('--assume-if-true', dest='assume_if_true', action='store_true',
                         help="add true properties as assumptions. (Default is \"%s\")"%False)
 
+general_solving_options.set_defaults(skip_embedded=False)
+general_solving_options.add_argument('--skip-embedded', dest='skip_embedded', action='store_true',
+                        help="don't solve embedded assertions. (Default is \"%s\")"%False)
+
 general_encoding_options = cosa_option_manager.add_general_group('encoding')
 
 general_encoding_options.set_defaults(abstract_clock=False)


### PR DESCRIPTION
Adds an option that lets you skip solving embedded assertion (any assertion that is found when encoding the model).