### PR TITLE
Fix coreir compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ addons:
      - libmpc-dev
 
 install:
+  - bash ./scripts/travis_install.sh
   - pip install -e .
   - pysmt-install --msat --confirm-agreement --install-path solvers --bindings-path bindings
-  - bash ./scripts/travis_install.sh
   - chmod +x ./yosys
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-     - g++-4.9
+     - g++-7
      - clang
      - wget
      - unzip
@@ -49,6 +49,6 @@ install:
   - chmod +x ./yosys
 
 env:
- - PATH="$PATH:." PYTHONPATH="${TRAVIS_BUILD_DIR}/pycoreir":"${TRAVIS_BUILD_DIR}/solvers/":"${TRAVIS_BUILD_DIR}/bindings:${PYTHONPATH}" LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/coreir/lib":"${TRAVIS_BUILD_DIR}/bindings:${TRAVIS_BUILD_DIR}/solvers:${LD_LIBRARY_PATH}" COREIRCONFIG=clang++ CC=clang CXX=clang++
+ - PATH="$PATH:." PYTHONPATH="${TRAVIS_BUILD_DIR}/pycoreir":"${TRAVIS_BUILD_DIR}/solvers/":"${TRAVIS_BUILD_DIR}/bindings:${PYTHONPATH}" LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/coreir/lib":"${TRAVIS_BUILD_DIR}/bindings:${TRAVIS_BUILD_DIR}/solvers:${LD_LIBRARY_PATH}" COREIRCONFIG=g++-7 CC=gcc-7 CXX=g++-7
 
 script: nosetests tests -vv

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -1,26 +1,33 @@
 #!/bin/bash
 
-PYCOREIR="`pwd`/pycoreir/setup.py"
-COREIR="`pwd`/coreir/build"
+# PYCOREIR="`pwd`/pycoreir/setup.py"
+# COREIR="`pwd`/coreir/build"
 
-if [ ! -f "$COREIR" ]; then
-    rm -fr coreir*
-    wget https://github.com/rdaly525/coreir/archive/master.zip
-    unzip master.zip
-    rm master.zip
-    mv coreir-master coreir
-    cd coreir
-    mkdir build
-    cd build
-    cmake ..
-    make -j4 && sudo make install
-    cd ../../
-else
-    echo "Skipping COREIR installation"
-    cd coreir/build
-    make -j4 && sudo make install
-    cd ../../
-fi
+# if [ ! -f "$COREIR" ]; then
+#     rm -fr coreir*
+#     wget https://github.com/rdaly525/coreir/archive/master.zip
+#     unzip master.zip
+#     rm master.zip
+#     mv coreir-master coreir
+#     cd coreir
+#     mkdir build
+#     cd build
+#     cmake ..
+#     make -j4 && sudo make install
+#     cd ../../
+# else
+#     echo "Skipping COREIR installation"
+#     cd coreir/build
+#     make -j4 && sudo make install
+#     cd ../../
+# fi
+
+# use latest master instead of release
+pip uninstall coreir
+git clone https://github.com/leonardt/pycoreir.git
+cd pycoreir
+pip install cmake twine wheel pytest
+pip install -e .
 
 # Get yosys -- using for verilog frontend
 wget http://web.stanford.edu/~makaim/files/yosys.tar.xz

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -23,11 +23,11 @@
 # fi
 
 # use latest master instead of release
-pip uninstall coreir
 git clone https://github.com/leonardt/pycoreir.git
 cd pycoreir
 pip install cmake twine wheel pytest
 pip install -e .
+cd ../
 
 # Get yosys -- using for verilog frontend
 wget http://web.stanford.edu/~makaim/files/yosys.tar.xz


### PR DESCRIPTION
Use g++-7 and the latest version of `pycoreir` from master to fix the coreir build. Note: the build is technically failing, but master hasn't been run on Travis since the changes to coreir so it hasn't failed publicly yet.