### PR TITLE
Use -expose instead of -anyseq in Yosys setundef pass

### DIFF
--- a/cosa/encoders/verilog_yosys.py
+++ b/cosa/encoders/verilog_yosys.py
@@ -44,7 +44,7 @@ COMMANDS = []
 COMMANDS.append("read_verilog -nomem2reg -sv {FILES}")
 COMMANDS.append("prep -top {TARGET}")
 COMMANDS.append("{PASSES}")
-COMMANDS.append("setundef -undriven -anyseq")
+COMMANDS.append("setundef -undriven -expose")
 COMMANDS.append("write_btor {BTORFILE}")
 
 DFFSR2DFF_CMD = "yosys -p 'techmap -map +/dffsr2dff.v'"


### PR DESCRIPTION
Using the `-expose` option creates inputs to non-deterministically drive signals instead of using a state variable. This is preferable because then the state variable is not used in various model checking approaches, e.g. equivalence checking, loop free constraints in k-induction, etc...
