### PR TITLE
Redesign of BTOR encoder, includes lazy casting

### DIFF
--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -102,9 +102,9 @@ class BTOR2Converter:
         # these btor operators interpret some of the arguments as integers
         self.mixed_op_map = {
             # PySMT uses [low:high] for slicing, aka Extract
-            "slice"   : lambda s, x, h, l : BVExtract(B2BV(x), int(l), int(h)),
-            "uext"    : lambda s, x, w    : BVZExt(B2BV(x), int(w)),
-            "sext"    : lambda s, x, w    : BVSExt(B2BV(x), int(w)),
+            "slice"   : lambda s, x, h, l : BVExtract(B2BV(self.getnode(x)), int(l), int(h)),
+            "uext"    : lambda s, x, w    : BVZExt(B2BV(self.getnode(x)), int(w)),
+            "sext"    : lambda s, x, w    : BVSExt(B2BV(self.getnode(x)), int(w)),
             "zero"    : lambda s, w       : BV(0, int(w)),
             "one"     : lambda s, w       : BV(1, int(w)),
             "ones"    : lambda s, w       : BV((2**int(w))-1, int(w)),
@@ -170,9 +170,11 @@ class BTOR2Converter:
             self.ts.add_state_var(self.nodemap[nid])
 
         elif ntype == NEXT:
-            # state elements are always bit-vectors -- convert the righthand side if necessary
-            lval = TS.get_prime(getnode(nids[1]))
-            rval = B2BV(self.getnode(nids[2]))
+            # state elements are never bool -- convert the righthand side if necessary
+            lval = TS.get_prime(self.getnode(nids[1]))
+            rval = self.getnode(nids[2])
+            if rval.get_type().is_bool_type():
+                rval = B2BV(rval)
 
             self.nodemap[nid] = EqualsOrIff(lval, rval)
             self.ftrans.append(

--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -1,96 +1,403 @@
-# Copyright 2018 Cristian Mattarei
-#
-# Licensed under the modified BSD (3-clause BSD) License.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-import os
-
 from pathlib import Path
-from typing import List, NamedTuple, Tuple
+from typing import Callable, Dict, List, NamedTuple, Set, Tuple, Union
 
+from pysmt.exceptions import PysmtTypeError
 from pysmt.fnode import FNode
 from pysmt.shortcuts import Not, TRUE, And, BVNot, BVNeg, BVAnd, BVOr, BVAdd, Or, Symbol, BV, EqualsOrIff, \
     Implies, BVMul, BVExtract, BVUGT, BVUGE, BVULT, BVULE, BVSGT, BVSGE, BVSLT, BVSLE, \
     Ite, BVZExt, BVSExt, BVXor, BVConcat, get_type, BVSub, Xor, Select, Store, BVComp, simplify, \
-    BVLShl, BVAShr, BVLShr
-from pysmt.typing import BOOL, BVType, ArrayType
+    BVLShl, BVAShr, BVLShr, BVType, ArrayType
+from pysmt.typing import PySMTType
 
-from cosa.representation import HTS, TS
-from cosa.encoders.formulae import StringParser
-from cosa.utils.logger import Logger
-from cosa.utils.formula_mngm import quote_names, B2BV, BV2B
-from cosa.utils.generic import bin_to_dec
 from cosa.encoders.template import ModelParser
+from cosa.representation import HTS, TS
+from cosa.utils.logger import Logger
+from cosa.utils.formula_mngm import B2BV, BV2B
 
 NL = "\n"
 COLON_REP = "_c_"
-
 SN="N%s"
-
 COM=";"
-SORT="sort"
-BITVEC="bitvec"
-ARRAY="array"
-WRITE="write"
-READ="read"
-ZERO="zero"
-ONE="one"
-ONES="ones"
-STATE="state"
-INPUT="input"
-OUTPUT="output"
-ADD="add"
-EQ="eq"
-NEQ="neq"
-MUL="mul"
-SLICE="slice"
-CONST="const"
-CONSTD="constd"
-UGT="ugt"
-UGTE="ugte"
-ULT="ult"
-ULTE="ulte"
-SGT="sgt"
-SGTE="sgte"
-SLT="slt"
-SLTE="slte"
-AND="and"
-XOR="xor"
-XNOR = "xnor"
-NAND="nand"
-IMPLIES="implies"
-OR="or"
-ITE="ite"
-NOT="not"
-NEG="neg"
-REDOR="redor"
-REDAND="redand"
-UEXT="uext"
-SEXT="sext"
-CONCAT="concat"
-SUB="sub"
-SLL="sll"
-SRA="sra"
-SRL="srl"
-
-INIT="init"
-NEXT="next"
-CONSTRAINT="constraint"
-BAD="bad"
 ASSERTINFO="btor-assert"
 
+STATE="state"
+NEXT="next"
+INIT="init"
+INPUT="input"
+OUTPUT="output"
+BAD="bad"
+CONSTRAINT="constraint"
+JUSTICE="justice"
+
 special_char_replacements = {"$": "", "\\": ".", ":": COLON_REP}
+
+# BTOR2Converter is kept separate from the parser to keep all state-ful elements separate
+# Thus, BTOR2Parser can be re-used for multiple BTOR files, but BTOR2Converter must be
+# initialized each time
+class BTOR2Converter:
+    '''
+    Class used to map BTOR operators to the equivalent PySMT functions
+
+    Utilized by BTOR2Parser
+    '''
+    def __init__(self):
+        self.hts = HTS()
+        self.ts = TS()
+
+        self.nodemap = {}
+        self.node_covered = set()
+
+        # list of tuples of var and cond_assign_list
+        # cond_assign_list is tuples of (condition, value)
+        # where everything is a pysmt FNode
+        # for btor, the condition is always True
+        self.ftrans = []
+        self.initlist = []
+        self.invarlist = []
+
+        self.invar_props = []
+        self.ltl_props = []
+        self.prop_count = 0
+
+        # converter should only be used once
+        self.converted = False
+
+        #TODO: look into a more optimal way of passing arguments, constantly packing and unpacking tuples now
+
+        # These btor operators take FNodes for every option
+        # Thus the arguments are implicitly converted to FNodes first by looking up the id in the nodemap
+        self.all_fnode_op_map = {
+            "implies" : lambda p, q    : BTOR2Converter._apply_bool_op(Implies, p, q),
+            "eq"      : lambda x, y    : BTOR2Converter._apply_bv_or_bool_op(BVComp, EqualsOrIff, x, y),
+            "neq"     : lambda x, y    : BTOR2Converter._apply_bv_or_bool_op(BVComp, EqualsOrIff, x, y, negate=True),
+            "and"     : lambda *args   : BTOR2Converter._apply_bv_or_bool_op(BVAnd, And, *args),
+            "or"      : lambda *args   : BTOR2Converter._apply_bv_or_bool_op(BVOr, Or, *args),
+            "xor"     : lambda *args   : BTOR2Converter._apply_bv_or_bool_op(BVXor, Xor, *args),
+            "xnor"    : lambda *args   : BTOR2Converter._apply_bv_or_bool_op(BVXor, Xor, *args, negate=True),
+            "nand"    : lambda *args   : BTOR2Converter._apply_bv_or_bool_op(BVAnd, And, *args, negate=True),
+            "not"     : lambda a       : BTOR2Converter._apply_bv_or_bool_op(BVNot, Not, a),
+            "neg"     : lambda a       : BTOR2Converter._apply_bv_or_bool_op(BVNeg, BTOR2Converter._identity, a),
+            "add"     : lambda *args   : BTOR2Converter._apply_bv_op(BVAdd, *args),
+            "sub"     : lambda *args   : BTOR2Converter._apply_bv_op(BVSub, *args),
+            "ugt"     : lambda *args   : BTOR2Converter._apply_bv_op(BVUGT, *args),
+            "ugte"    : lambda *args   : BTOR2Converter._apply_bv_op(BVUGTE, *args),
+            "ult"     : lambda *args   : BTOR2Converter._apply_bv_op(BVULT, *args),
+            "ulte"    : lambda *args   : BTOR2Converter._apply_bv_op(BVULTE, *args),
+            "sgt"     : lambda *args   : BTOR2Converter._apply_bv_op(BVSGT, *args),
+            "sgte"    : lambda *args   : BTOR2Converter._apply_bv_op(BVSGTE, *args),
+            "slt"     : lambda *args   : BTOR2Converter._apply_bv_op(BVSLT, *args),
+            "slte"    : lambda *args   : BTOR2Converter._apply_bv_op(BVSLTE, *args),
+            "mul"     : lambda *args   : BTOR2Converter._apply_bv_op(BVMul, *args),
+            "sll"     : lambda x, y    : BTOR2Converter._apply_bv_op(BVLShl, x, y),
+            "sra"     : lambda x, y    : BTOR2Converter._apply_bv_op(BVAShr, x, y),
+            "srl"     : lambda x, y    : BTOR2Converter._apply_bv_op(BVLShr, x, y),
+            "concat"  : lambda *args   : BTOR2Converter._apply_bv_op(BVConcat, *args),
+            "write"   : BTOR2Converter._store,
+            "read"    : BTOR2Converter._select,
+            "ite"     : BTOR2Converter._ite,
+            "redor"   : BTOR2Converter._redor,
+            "redand"  : BTOR2Converter._redand
+        }
+
+        # these btor operators interpret some of the arguments as integers
+        self.mixed_op_map = {
+            # PySMT uses [low:high] for slicing, aka Extract
+            "slice"   : lambda x, h, l : BVExtract(B2BV(x), int(l), int(h)),
+            "uext"    : lambda x, w    : BVZExt(B2BV(x), int(w)),
+            "sext"    : lambda x, w    : BVSExt(B2BV(x), int(w)),
+            "zero"    : lambda w       : BV(0, int(w)),
+            "one"     : lambda w       : BV(1, int(w)),
+            "ones"    : lambda w       : BV((2**int(w))-1, int(w)),
+            "constd"  : lambda s, a    : BV(int(a), self.getnode(s).width),
+            "const"   : lambda s, a    : BV(int(a, 2), self.getnode(s).width),
+            "consth"  : lambda s, a    : BV(int(a, 16), self.getnode(s).width),
+            "sort"    : BTOR2Converter._to_pysmt_type
+        }
+
+    def getnode(self, nid:str)->FNode:
+        self.node_covered.add(nid)
+        return self.nodemap[nid]
+
+    def convert(self, lines:List[str])->Tuple[HTS, List[FNode], List[FNode]]:
+        if self.converted:
+            # converter should only be used once
+            raise RuntimeError("Should not be calling convert more than once, construct a new object")
+
+        for line in lines:
+            linetok = line.split()
+            if len(linetok) == 0:
+                continue
+            if linetok[0] == COM:
+                continue
+
+            (nid, ntype, *nids) = linetok
+            self.process_line(nid, ntype, nids)
+
+        self.converted = True
+
+        if Logger.level(1):
+            name = lambda x: str(self.nodemap[x]) if self.nodemap[x].is_symbol() else x
+            uncovered = [name(x) for x in self.nodemap if x not in self.node_covered]
+            uncovered.sort()
+            if len(uncovered) > 0:
+                Logger.warning("Unlinked nodes \"%s\""%",".join(uncovered))
+
+        if not self.symbolic_init:
+            init = simplify(And(initlist))
+        else:
+            init = TRUE()
+
+        invar = simplify(And(invarlist))
+
+        # instead of trans, we're using the ftrans format -- see below
+        self.ts.set_behavior(init, TRUE(), invar)
+
+        # add ftrans
+        for var, cond_assign_list in ftrans:
+            ts.add_func_trans(var, cond_assign_list)
+
+        self.hts.add_ts(ts)
+
+        return (self.hts, self.invar_props, self.ltl_props)
+
+
+    def process_line(self, nid:str, ntype:str, nids:Tuple[str])->None:
+        if ntype == STATE:
+            if len(nids) > 1:
+                self.nodemap[nid] = Symbol(nids[1], self.getnode(nids[0]))
+            else:
+                self.nodemap[nid] = Symbol((SN%nid), self.getnode(nids[0]))
+            self.ts.add_state_var(self.nodemap[nid])
+
+        elif ntype == NEXT:
+            # state elements are always bit-vectors -- convert the righthand side if necessary
+            lval = TS.get_prime(getnode(nids[1]))
+            rval = B2BV(self.getnode(nids[2]))
+
+            self.nodemap[nid] = EqualsOrIff(lval, rval)
+            self.ftrans.append(
+                (lval,
+                 [(TRUE(), rval)])
+            )
+
+        elif ntype == INPUT:
+            if len(nids) > 1:
+                self.nodemap[nid] = Symbol(nids[1], self.getnode(nids[0]))
+            else:
+                self.nodemap[nid] = Symbol((SN%nid), self.getnode(nids[0]))
+            self.ts.add_input_var(nodemap[nid])
+
+        elif ntype == OUTPUT:
+            # unfortunately we need to create an extra symbol just to have the output name
+            # we could be smarter about this, but then this parser can't be greedy
+            original_symbol = self.getnode(nids[0])
+            output_symbol = Symbol(nids[1], original_symbol.get_type())
+            self.nodemap[nid] = EqualsOrIff(output_symbol, original_symbol)
+            self.invarlist.append(self.nodemap[nid])
+            self.node_covered.add(nid)
+            self.ts.add_output_var(output_symbol)
+
+        elif ntype == INIT:
+            nid1, nid2 = self.getnode(nids[1]), self.getnode(nids[2])
+            if (get_type(nid1) == BOOL) or (get_type(nid2) == BOOL):
+                node = EqualsOrIff(BV2B(nid1), BV2B(nid2))
+            else:
+                node = EqualsOrIff(nid1, nid2)
+            self.nodemap[nid] = node
+            self.initlist.append(node)
+
+        elif ntype == CONSTRAINT:
+            node = BV2B(getnode(nids[0]))
+            self.nodemap[nid] = node
+            self.invarlist.append(node)
+
+        elif ntype == BAD:
+            nodemap[nid] = getnode(nids[0])
+
+            if ASSERTINFO in line:
+                filename_lineno = os.path.basename(nids[3])
+                assert_name = 'embedded_assertion_%s'%filename_lineno
+                description = "Embedded assertion at line {1} in {0}".format(*filename_lineno.split(COLON_REP))
+            else:
+                assert_name = 'embedded_assertion_%i'%prop_count
+                description = 'Embedded assertion number %i'%prop_count
+                prop_count += 1
+
+            # Following problem format (name, description, strformula)
+            self.invar_props.append((assert_name, description, Not(BV2B(self.getnode(nid)))))
+
+        elif ntype == JUSTICE:
+            raise RuntimeError("Justice (e.g. Buchi automata / liveness) properties are not yet supported for BTOR")
+
+        elif ntype in self.all_fnode_op_map:
+            nids = [self.getnode(a) for a in nids]
+            self.nodemap[nid] = self.all_fnode_op_map[ntype](*nids)
+
+        elif ntype in self.mixed_op_map:
+            self.nodemap[nid] = self.mixed_op_map[ntype](*nids)
+
+        else:
+            raise RuntimeError("Unhandled combinational BTOR op: {}".format(ntype))
+
+        # get wirenames for signals
+        # unfortunately we need to create a new symbol for this -- e.g. there's no define-fun
+        if ntype not in {STATE, INPUT, OUTPUT, BAD}:
+            # check for wirename, if it's an integer, then it's a node ref not a wirename
+            try:
+                a = int(nids[-1])
+            except:
+                try:
+                    wire = Symbol(str(nids[-1]), getnode(nids[0]))
+                    self.invarlist.append(EqualsOrIff(wire, B2BV(self.nodemap[nid])))
+                    self.ts.add_var(wire)
+                except:
+                    pass
+
+
+    @staticmethod
+    def _identity(a):
+        return a
+
+    @staticmethod
+    def _to_pysmt_type(sort:str, *args)->PySMTType:
+        if sort == "bitvec":
+            return BVType(int(args[0]))
+        elif sort == "array":
+            return ArrayType(self.getnode(args[0]), self.getnode(args[1]))
+        else:
+            raise RuntimeError("Unsupported btor sort: {}".format(sort))
+
+    @staticmethod
+    def _apply_bv_or_bool_op(bv_op:Callable[...,FNode],
+                             bool_op:Callable[...,FNode],
+                             *args:FNode,
+                             negate:bool=False
+                             )->FNode:
+        '''
+        Applies a bit-vector or bool op, with preference for the bit-vector operator.
+        '''
+        _types = [a.get_type() for a in args]
+
+        assert [t.is_bool_type() or t.is_bv_type() for t in _types], \
+            "Expecting all booleans or all bv"
+
+        num_bv_args = sum([t.is_bv_type() for t in _types])
+
+        # preference for bit-vector operations
+        if num_bv_args > len(_types)/2:
+            return BTOR2Parser._apply_bv_op(bv_op, args, negate=negate)
+        else:
+            return BTOR2Parser._apply_bool_op(bool_op, args, negate=negate)
+
+    @staticmethod
+    def _apply_bv_op(bv_op:Callable[...,FNode], *args:FNode, negate:bool=False)->FNode:
+        try:
+            res = bv_op(*args)
+        except (AssertionError, PysmtTypeError) as e:
+            # cast to bv
+            casted_args = [B2BV(a) for a in args]
+            res = bv_op(*casted_args)
+
+        if negate:
+            res = BVNot(res)
+
+        return res
+
+    @staticmethod
+    def _apply_bool_op(bool_op:Callable[...,FNode], *args:FNode, negate:bool=False)->FNode:
+        try:
+            res = bool_op(*args)
+        except (AssertionError, PysmtTypeError) as e:
+            # cast to bool
+            casted_args = [BV2B(a) for a in args]
+            res =  bool_op(*casted_args)
+
+        if negate:
+            res = Not(res)
+
+        return res
+
+    @staticmethod
+    def _ite(c:FNode, a:FNode, b:FNode)->FNode:
+        ct, at, bt = c.get_type(), a.get_type(), b.get_type()
+
+        if not ct.is_bool_type():
+            assert ct.is_bv_type() and ct.width == 1, "Expecting a bit-vector of size one if not a bool"
+            c = EqualsOrIff(c, BV(1, 1))
+
+        if at != bt:
+            try:
+                return Ite(c, B2BV(a), B2BV(b))
+            except:
+                raise ValueError("Couldn't correctly cast ite({}, {}, {})".format(c, a, b))
+        else:
+            return Ite(c, a, b)
+
+    @staticmethod
+    def _redor(arg:FNode)->FNode:
+        width = get_type(arg).width
+        zeros = BV(0, width)
+        return BVNot(BVComp(arg, zeros))
+
+    @staticmethod
+    def _redand(arg:FNode)->FNode:
+        width = get_type(arg).width
+        ones = BV((2**width)-1, width)
+        return BVComp(arg, ones)
+
+    @staticmethod
+    def _store(arr:FNode, idx:FNode, val:FNode)->FNode:
+        try:
+            return Store(arr, idx, val)
+        except (AssertionError, PysmtTypeError) as e:
+            _type = arr.get_type()
+            assert _type.is_array_type(), "Expecting array type"
+
+            idx_type, elem_type = idx.get_type(), val.get_type()
+            arr_idx_type, arr_elem_type = _type.index_type, _type.elem_type
+
+            if idx_type != arr_idx_type:
+                if idx_type.is_bool_type() and arr_idx_type.is_bv_type():
+                    idx = B2BV(idx)
+                elif idx_type.is_bv_type() and arr_idx_type.is_bool_type():
+                    idx = BV2B(idx)
+                else:
+                    raise RuntimeError("Can't cast {} to {}".format(idx, arr_idx_type))
+
+            if elem_type != arr_elem_type:
+                if elem_type.is_bool_type() and arr_elem_type.is_bv_type():
+                    val = B2BV(val)
+                elif elem_type.is_bv_type() and arr_elem_type.is_bool_type():
+                    val = BV2B(val)
+                else:
+                    raise RuntimeError("Can't cast {} to {}".format(val, arr_elem_type))
+
+            return Store(arr, idx, val)
+
+    @staticmethod
+    def _select(arr:FNode, idx:FNode)->FNode:
+        try:
+            return Select(arr, idx)
+        except (AssertionError, PysmtTypeError) as e:
+            _type = arr.get_type()
+            assert _type.is_array_type(), "Expecting array type"
+
+            idx_type, arr_idx_type = idx.get_type(), arr.index_type
+
+            if idx_type.is_bool_type() and arr_idx_type.is_bv_type():
+                idx = B2BV(idx)
+            elif idx_type.is_bv_type() and arr_idx_type.is_bool_type():
+                idx = BV2B(idx)
+            else:
+                raise RuntimeError("Can't cast {} to {}".format(idx, arr_idx_type))
+
+            return Select(arr, idx)
+
 
 class BTOR2Parser(ModelParser):
     parser = None
     extensions = ["btor2","btor"]
     name = "BTOR2"
-    symbolic_init = False
 
     def __init__(self):
         pass
@@ -116,309 +423,11 @@ class BTOR2Parser(ModelParser):
     def get_extensions():
         return BTOR2Parser.extensions
 
-    def remap_an2or(self, name):
-        return name
-
-    def remap_or2an(self, name):
-        return name
-
-    def parse_string(self, strinput):
-
-        hts = HTS()
-        ts = TS()
-
-        nodemap = {}
-        node_covered = set([])
-
-        # list of tuples of var and cond_assign_list
-        # cond_assign_list is tuples of (condition, value)
-        # where everything is a pysmt FNode
-        # for btor, the condition is always True
-        ftrans = []
-
-        initlist = []
-        invarlist = []
-
-        invar_props = []
-        ltl_props = []
-
-        prop_count = 0
+    def parse_string(self, strinput:str)->Tuple[HTS, List[FNode], List[FNode]]:
+        converter = BTOR2Converter()
 
         # clean string input, remove special characters from names
         for sc, rep in special_char_replacements.items():
             strinput = strinput.replace(sc, rep)
 
-        def getnode(nid):
-            node_covered.add(nid)
-            if int(nid) < 0:
-                return Ite(BV2B(nodemap[str(-int(nid))]), BV(0,1), BV(1,1))
-            return nodemap[nid]
-
-        def binary_op(bvop, bop, left, right):
-            if (get_type(left) == BOOL) and (get_type(right) == BOOL):
-                return bop(left, right)
-            return bvop(B2BV(left), B2BV(right))
-
-        def unary_op(bvop, bop, left):
-            if (get_type(left) == BOOL):
-                return bop(left)
-            return bvop(left)
-
-        for line in strinput.split(NL):
-            linetok = line.split()
-            if len(linetok) == 0:
-                continue
-            if linetok[0] == COM:
-                continue
-
-            (nid, ntype, *nids) = linetok
-
-            if ntype == SORT:
-                (stype, *attr) = nids
-                if stype == BITVEC:
-                    nodemap[nid] = BVType(int(attr[0]))
-                    node_covered.add(nid)
-                if stype == ARRAY:
-                    nodemap[nid] = ArrayType(getnode(attr[0]), getnode(attr[1]))
-                    node_covered.add(nid)
-
-            if ntype == WRITE:
-                nodemap[nid] = Store(*[getnode(n) for n in nids[1:4]])
-
-            if ntype == READ:
-                nodemap[nid] = Select(getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == ZERO:
-                nodemap[nid] = BV(0, getnode(nids[0]).width)
-
-            if ntype == ONE:
-                nodemap[nid] = BV(1, getnode(nids[0]).width)
-
-            if ntype == ONES:
-                width = getnode(nids[0]).width
-                nodemap[nid] = BV((2**width)-1, width)
-
-            if ntype == REDOR:
-                width = get_type(getnode(nids[1])).width
-                zeros = BV(0, width)
-                nodemap[nid] = BVNot(BVComp(getnode(nids[1]), zeros))
-
-            if ntype == REDAND:
-                width = get_type(getnode(nids[1])).width
-                ones = BV((2**width)-1, width)
-                nodemap[nid] = BVComp(getnode(nids[1]), ones)
-
-            if ntype == CONSTD:
-                width = getnode(nids[0]).width
-                nodemap[nid] = BV(int(nids[1]), width)
-
-            if ntype == CONST:
-                width = getnode(nids[0]).width
-                try:
-                    nodemap[nid] = BV(bin_to_dec(nids[1]), width)
-                except ValueError:
-                    if not all([i == 'x' or i == 'z' for i in nids[1]]):
-                        raise RuntimeError("If not a valid number, only support "
-                                           "all don't cares or high-impedance but got {}".format(nids[1]))
-                    # create a fresh variable for this non-deterministic constant
-                    nodemap[nid] = Symbol('const_'+nids[1], BVType(width))
-                    ts.add_state_var(nodemap[nid])
-                    Logger.warning("Creating a fresh symbol for unsupported X/Z constant %s"%nids[1])
-
-            if ntype == STATE:
-                if len(nids) > 1:
-                    nodemap[nid] = Symbol(nids[1], getnode(nids[0]))
-                else:
-                    nodemap[nid] = Symbol((SN%nid), getnode(nids[0]))
-                ts.add_state_var(nodemap[nid])
-
-            if ntype == INPUT:
-                if len(nids) > 1:
-                    nodemap[nid] = Symbol(nids[1], getnode(nids[0]))
-                else:
-                    nodemap[nid] = Symbol((SN%nid), getnode(nids[0]))
-                ts.add_input_var(nodemap[nid])
-
-            if ntype == OUTPUT:
-                # unfortunately we need to create an extra symbol just to have the output name
-                # we could be smarter about this, but then this parser can't be greedy
-                original_symbol = getnode(nids[0])
-                output_symbol = Symbol(nids[1], original_symbol.get_type())
-                nodemap[nid] = EqualsOrIff(output_symbol, original_symbol)
-                invarlist.append(nodemap[nid])
-                node_covered.add(nid)
-                ts.add_output_var(output_symbol)
-
-            if ntype == AND:
-                nodemap[nid] = binary_op(BVAnd, And, getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == CONCAT:
-                nodemap[nid] = BVConcat(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == XOR:
-                nodemap[nid] = binary_op(BVXor, Xor, getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == XNOR:
-                nodemap[nid] = BVNot(binary_op(BVXor, Xor, getnode(nids[1]), getnode(nids[2])))
-
-            if ntype == NAND:
-                bvop = lambda x,y: BVNot(BVAnd(x, y))
-                bop = lambda x,y: Not(And(x, y))
-                nodemap[nid] = binary_op(bvop, bop, getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == IMPLIES:
-                nodemap[nid] = BVOr(BVNot(getnode(nids[1])), getnode(nids[2]))
-
-            if ntype == NOT:
-                nodemap[nid] = unary_op(BVNot, Not, getnode(nids[1]))
-
-            if ntype == NEG:
-                nodemap[nid] = unary_op(BVNeg, Not, getnode(nids[1]))
-
-            if ntype == UEXT:
-                nodemap[nid] = BVZExt(B2BV(getnode(nids[1])), int(nids[2]))
-
-            if ntype == SEXT:
-                nodemap[nid] = BVSExt(B2BV(getnode(nids[1])), int(nids[2]))
-
-            if ntype == OR:
-                nodemap[nid] = binary_op(BVOr, Or, getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == ADD:
-                nodemap[nid] = BVAdd(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == SUB:
-                nodemap[nid] = BVSub(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == UGT:
-                nodemap[nid] = BVUGT(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == UGTE:
-                nodemap[nid] = BVUGE(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == ULT:
-                nodemap[nid] = BVULT(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == ULTE:
-                nodemap[nid] = BVULE(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == SGT:
-                nodemap[nid] = BVSGT(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == SGTE:
-                nodemap[nid] = BVSGE(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == SLT:
-                nodemap[nid] = BVSLT(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == SLTE:
-                nodemap[nid] = BVSLE(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == EQ:
-                nodemap[nid] = BVComp(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == NEQ:
-                nodemap[nid] = BVNot(BVComp(getnode(nids[1]), getnode(nids[2])))
-
-            if ntype == MUL:
-                nodemap[nid] = BVMul(B2BV(getnode(nids[1])), B2BV(getnode(nids[2])))
-
-            if ntype == SLICE:
-                nodemap[nid] = BVExtract(B2BV(getnode(nids[1])), int(nids[3]), int(nids[2]))
-
-            if ntype == SLL:
-                nodemap[nid] = BVLShl(getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == SRA:
-                nodemap[nid] = BVAShr(getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == SRL:
-                nodemap[nid] = BVLShr(getnode(nids[1]), getnode(nids[2]))
-
-            if ntype == ITE:
-                if (get_type(getnode(nids[2])) == BOOL) or (get_type(getnode(nids[3])) == BOOL):
-                    nodemap[nid] = Ite(BV2B(getnode(nids[1])), B2BV(getnode(nids[2])), B2BV(getnode(nids[3])))
-                else:
-                    nodemap[nid] = Ite(BV2B(getnode(nids[1])), getnode(nids[2]), getnode(nids[3]))
-
-            if ntype == NEXT:
-                if (get_type(getnode(nids[1])) == BOOL) or (get_type(getnode(nids[2])) == BOOL):
-                    lval = TS.get_prime(getnode(nids[1]))
-                    rval = BV2B(getnode(nids[2]))
-                else:
-                    lval = TS.get_prime(getnode(nids[1]))
-                    rval = getnode(nids[2])
-
-                nodemap[nid] = EqualsOrIff(lval, rval)
-
-                ftrans.append(
-                     (lval,
-                     [(TRUE(), rval)])
-                )
-
-            if ntype == INIT:
-                if (get_type(getnode(nids[1])) == BOOL) or (get_type(getnode(nids[2])) == BOOL):
-                    nodemap[nid] = EqualsOrIff(BV2B(getnode(nids[1])), BV2B(getnode(nids[2])))
-                else:
-                    nodemap[nid] = EqualsOrIff(getnode(nids[1]), getnode(nids[2]))
-                initlist.append(getnode(nid))
-
-            if ntype == CONSTRAINT:
-                nodemap[nid] = BV2B(getnode(nids[0]))
-                invarlist.append(getnode(nid))
-
-            if ntype == BAD:
-                nodemap[nid] = getnode(nids[0])
-
-                if ASSERTINFO in line:
-                    filename_lineno = os.path.basename(nids[3])
-                    assert_name = 'embedded_assertion_%s'%filename_lineno
-                    description = "Embedded assertion at line {1} in {0}".format(*filename_lineno.split(COLON_REP))
-                else:
-                    assert_name = 'embedded_assertion_%i'%prop_count
-                    description = 'Embedded assertion number %i'%prop_count
-                    prop_count += 1
-
-                # Following problem format (name, description, strformula)
-                invar_props.append((assert_name, description, Not(BV2B(getnode(nid)))))
-
-            if nid not in nodemap:
-                Logger.error("Unknown node type \"%s\""%ntype)
-
-            # get wirename if it exists
-            if ntype not in {STATE, INPUT, OUTPUT, BAD}:
-                # check for wirename, if it's an integer, then it's a node ref
-                try:
-                    a = int(nids[-1])
-                except:
-                    try:
-                        wire = Symbol(str(nids[-1]), getnode(nids[0]))
-                        invarlist.append(EqualsOrIff(wire, B2BV(nodemap[nid])))
-                        ts.add_var(wire)
-                    except:
-                        pass
-
-        if Logger.level(1):
-            name = lambda x: str(nodemap[x]) if nodemap[x].is_symbol() else x
-            uncovered = [name(x) for x in nodemap if x not in node_covered]
-            uncovered.sort()
-            if len(uncovered) > 0:
-                Logger.warning("Unlinked nodes \"%s\""%",".join(uncovered))
-
-        if not self.symbolic_init:
-            init = simplify(And(initlist))
-        else:
-            init = TRUE()
-
-        invar = simplify(And(invarlist))
-
-        # instead of trans, we're using the ftrans format -- see below
-        ts.set_behavior(init, TRUE(), invar)
-
-        # add ftrans
-        for var, cond_assign_list in ftrans:
-            ts.add_func_trans(var, cond_assign_list)
-
-        hts.add_ts(ts)
-
-        return (hts, invar_props, ltl_props)
+        return converter.convert(strinput.split(NL))

--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -18,7 +18,6 @@ NL = "\n"
 COLON_REP = "_c_"
 SN="N%s"
 COM=";"
-ASSERTINFO="btor-assert"
 
 STATE="state"
 NEXT="next"
@@ -57,7 +56,6 @@ class BTOR2Converter:
 
         self.invar_props = []
         self.ltl_props = []
-        self.prop_count = 0
 
         # converter should only be used once
         self.converted = False
@@ -237,15 +235,6 @@ class BTOR2Converter:
 
         elif ntype == BAD:
             nodemap[nid] = getnode(nids[0])
-
-            if ASSERTINFO in line:
-                filename_lineno = os.path.basename(nids[3])
-                assert_name = 'embedded_assertion_%s'%filename_lineno
-                description = "Embedded assertion at line {1} in {0}".format(*filename_lineno.split(COLON_REP))
-            else:
-                assert_name = 'embedded_assertion_%i'%prop_count
-                description = 'Embedded assertion number %i'%prop_count
-                prop_count += 1
 
             # Following problem format (name, description, strformula)
             self.invar_props.append((assert_name, description, Not(BV2B(self.getnode(nid)))))

--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -19,6 +19,7 @@ COLON_REP = "_c_"
 SN="N%s"
 COM=";"
 
+SORT="sort"
 STATE="state"
 NEXT="next"
 INIT="init"
@@ -109,7 +110,6 @@ class BTOR2Converter:
             "constd"  : lambda s, a       : BV(int(a), self.getnode(s).width),
             "const"   : lambda s, a       : BV(int(a, 2), self.getnode(s).width),
             "consth"  : lambda s, a       : BV(int(a, 16), self.getnode(s).width),
-            "sort"    : self._to_pysmt_type
         }
 
     def getnode(self, nid:str)->FNode:
@@ -182,7 +182,16 @@ class BTOR2Converter:
 
     def process_line(self, nid:str, ntype:str, nids:Tuple[str])->None:
 
-        if ntype == STATE:
+        if ntype == SORT:
+            (stype, *attr) = nids
+            if stype == 'bitvec':
+                self.nodemap[nid] = BVType(int(attr[0]))
+                self.node_covered.add(nid)
+            if stype == 'array':
+                self.nodemap[nid] = ArrayType(self.getnode(attr[0]), self.getnode(attr[1]))
+                self.node_covered.add(nid)
+
+        elif ntype == STATE:
             if len(nids) > 1:
                 self.nodemap[nid] = Symbol(nids[1], self.getnode(nids[0]))
             else:
@@ -252,19 +261,11 @@ class BTOR2Converter:
             self.nodemap[nid] = self.mixed_op_map[ntype](*nids)
 
         else:
-            raise RuntimeError("Unhandled combinational BTOR op: {}".format(ntype))
+            raise RuntimeError("Unhandled BTOR op: {}".format(ntype))
 
     @staticmethod
     def _identity(a):
         return a
-
-    def _to_pysmt_type(self, sort:str, *args)->PySMTType:
-        if sort == "bitvec":
-            return BVType(int(args[0]))
-        elif sort == "array":
-            return ArrayType(self.getnode(args[0]), self.getnode(args[1]))
-        else:
-            raise RuntimeError("Unsupported btor sort: {}".format(sort))
 
     @staticmethod
     def _apply_bv_or_bool_op(bv_op:Callable[...,FNode],

--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -155,7 +155,16 @@ class BTOR2Converter:
         self.converted = True
 
         if Logger.level(1):
-            name = lambda x: str(self.nodemap[x]) if self.nodemap[x].is_symbol() else x
+            def name(x):
+                try:
+                    n = self.nodemap[x]
+                    if n.is_symbol():
+                        return str(n)
+                    else:
+                        return x
+                except:
+                    return x
+
             uncovered = [name(x) for x in self.nodemap if x not in self.node_covered]
             uncovered.sort()
             if len(uncovered) > 0:

--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -56,6 +56,7 @@ class BTOR2Converter:
 
         self.invar_props = []
         self.ltl_props = []
+        self.prop_count = 0
 
         # converter should only be used once
         self.converted = False
@@ -238,15 +239,18 @@ class BTOR2Converter:
             self.initlist.append(node)
 
         elif ntype == CONSTRAINT:
-            node = BV2B(getnode(nids[0]))
+            node = BV2B(self.getnode(nids[0]))
             self.nodemap[nid] = node
             self.invarlist.append(node)
 
         elif ntype == BAD:
-            nodemap[nid] = getnode(nids[0])
+            self.nodemap[nid] = self.getnode(nids[0])
 
             # Following problem format (name, description, strformula)
-            self.invar_props.append((assert_name, description, Not(BV2B(self.getnode(nid)))))
+            self.invar_props.append(("embedded_assertion_%i"%self.prop_count,
+                                     "Embedded assertion number %i"%self.prop_count,
+                                     Not(BV2B(self.getnode(nid)))))
+            self.prop_count += 1
 
         elif ntype == JUSTICE:
             raise RuntimeError("Justice (e.g. Buchi automata / liveness) properties are not yet supported for BTOR")


### PR DESCRIPTION
This would restructure the BTOR encoder to use a dictionary look-up for each function, instead of a sequence of `if`s. Furthermore, it lazily casts between `bool` and `BV(1)` with a preference for `BV(1)`. 

This is passing tests locally, but I'm not sure that it's ready to be merged yet which is why it's a draft. In particular, I'm not sure that it's robust to updates. For example, it expects the exact right number of tokens on each line, based on the operator. Yosys occasionally appends wirenames to a line, even if they're not state elements (which I don't think is standard BTOR), so we have to search for these and remove them before passing to the dictionary-lookup functions. Do you think this makes sense or would you prefer a different approach?