### PR TITLE
BUGFIX: cast the next-state update to a bit-vector

### DIFF
--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -344,7 +344,7 @@ class BTOR2Parser(ModelParser):
             if ntype == NEXT:
                 if (get_type(getnode(nids[1])) == BOOL) or (get_type(getnode(nids[2])) == BOOL):
                     lval = TS.get_prime(getnode(nids[1]))
-                    rval = BV2B(getnode(nids[2]))
+                    rval = B2BV(getnode(nids[2]))
                 else:
                     lval = TS.get_prime(getnode(nids[1]))
                     rval = getnode(nids[2])


### PR DESCRIPTION
State elements are always bit-vectors so the next-state update should be casted to a bit-vector. Instead, the current encoder tried to cast to bool if it detected that the types did not match. This pull request fixes this issue.