### PR TITLE
Use surrogate escape mode for errors reading ascii

### DIFF
--- a/cosa/encoders/btor2.py
+++ b/cosa/encoders/btor2.py
@@ -103,7 +103,7 @@ class BTOR2Parser(ModelParser):
                    config:NamedTuple,
                    flags:str=None)->Tuple[HTS, List[FNode], List[FNode]]:
         self.symbolic_init = config.symbolic_init
-        with filepath.open("r") as f:
+        with filepath.open("r", errors='surrogateescape') as f:
             return self.parse_string(f.read())
 
     def is_available(self):


### PR DESCRIPTION
Occasionally Yosys produces BTOR that is not valid ASCII or UTF-8. This extra option to `open` just handles this case by escaping the incorrect characters.