### PR TITLE
Add support for coreir undriven

### DIFF
--- a/cosa/encoders/coreir.py
+++ b/cosa/encoders/coreir.py
@@ -242,6 +242,7 @@ class CoreIRParser(ModelParser):
         mod_map.append(("concat", (Modules.Concat, [self.IN0, self.IN1, self.OUT])))
 
         mod_map.append(('term', (Modules.Term, [self.IN])))
+        mod_map.append(('undriven', (Modules.Undriven, [self.OUT])))
 
         self.mod_map = dict(mod_map)
 

--- a/cosa/encoders/modules.py
+++ b/cosa/encoders/modules.py
@@ -701,6 +701,16 @@ class Modules(object):
         ts = TS("Terminate wire")
         return ts
 
+    def Undriven(_out):
+        '''
+        Undriven is a no-op. _out is just undriven
+        '''
+        vars_ = [_out]
+        ts = TS("Undriven wire")
+        ts.vars = set(vars_)
+        return ts
+
+
 class ModuleSymbols(object):
 
     @staticmethod

--- a/tests/undriven/undriven_test.json
+++ b/tests/undriven/undriven_test.json
@@ -1,0 +1,27 @@
+{"top":"global.Top",
+ "namespaces":{
+   "global":{
+     "modules":{
+       "Top":{
+         "type":["Record",[
+           ["O0","Bit"],
+           ["O1",["Array",8,"Bit"]]
+         ]],
+         "instances":{
+           "inst0":{
+             "modref":"corebit.undriven"
+           },
+           "inst1":{
+             "genref":"coreir.undriven",
+             "genargs":{"width":["Int",8]}
+           }
+         },
+         "connections":[
+           ["self.O0","inst0.out"],
+           ["self.O1","inst1.out"]
+         ]
+       }
+     }
+   }
+ }
+ }


### PR DESCRIPTION
Adds the undriven primitive for CoreIR. It's just a symbol with no constraints (dual of Term).

@rsetaluri 
@leonardt